### PR TITLE
Update Windowmasker, remove tool_dependencies.xml

### DIFF
--- a/.shed.yml
+++ b/.shed.yml
@@ -1,4 +1,4 @@
-name: windowmasker_2_5_0
+name: windowmasker
 owner: yating-l
 description: Identify repetitive regions using WindowMasker
 type: unrestricted

--- a/tool_dependencies.xml
+++ b/tool_dependencies.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0"?>
-<tool_dependency>
-    <package name="blast" version="2.5.0">
-        <repository name="package_blast_plus_2_5_0" owner="iuc" />
-    </package>
-</tool_dependency>

--- a/windowmasker_macros.xml
+++ b/windowmasker_macros.xml
@@ -5,6 +5,7 @@
             Keep BLAST version in line with peterjc repo: https://github.com/peterjc/galaxy_blast
         -->
             <requirement type="package" version="2.7.1">blast</requirement>
+	    <requirement type="package">perl</requirement>
             <yield />
         </requirements>
     </xml>

--- a/windowmasker_macros.xml
+++ b/windowmasker_macros.xml
@@ -2,10 +2,9 @@
     <xml name="requirements">
         <requirements>
         <!--
-            Use older version of NCBI BLAST+ because 2.6.0 is available
-            through bioconda but not through the Galaxy toolshed
+            Keep BLAST version in line with peterjc repo: https://github.com/peterjc/galaxy_blast
         -->
-            <requirement type="package" version="2.5.0">blast</requirement>
+            <requirement type="package" version="2.7.1">blast</requirement>
             <yield />
         </requirements>
     </xml>

--- a/windowmasker_ustat.xml
+++ b/windowmasker_ustat.xml
@@ -32,7 +32,7 @@
 
         ## Convert WindowMasker interval output to BED format
         #if str($output_format) == "interval":
-            | ${__tool_directory__}/windowmasker_to_bed.pl > "${mask_output}"
+            | perl ${__tool_directory__}/windowmasker_to_bed.pl > "${mask_output}"
         #else
             -out "${mask_output}"
         #end if


### PR DESCRIPTION
This PR updates Windowmasker to use BLAST 2.7.1, the same one used in the main ncbi_blast_plus tools. It also removed to tool_depencies.xml file in line with current Galaxy practice.

Finally it adds perl as an explicit dependency.

All planemo tests succeed.